### PR TITLE
only grep for the first matching pid, in case there are multiple

### DIFF
--- a/setup-stage1.sh
+++ b/setup-stage1.sh
@@ -8,13 +8,13 @@ echo
 echo "This script will require you to open the FFXIV launcher from Lutris or Steam as if you were going to play the game normally"
 echo
 
-FFXIV_PID="$(ps axo pid,cmd | grep -Pi 'ffxivlauncher(|64).exe' | grep -vi grep | sed -e 's/^[[:space:]]*//' | cut -d' ' -f1)"
+FFXIV_PID="$(ps axo pid,cmd | grep -m 1 -Pi 'ffxivlauncher(|64).exe' | grep -vi grep | sed -e 's/^[[:space:]]*//' | cut -d' ' -f1)"
 
 if [[ "$FFXIV_PID" == "" ]]; then
     warn "Please open the FFXIV Launcher. Checking for process \"ffxivlauncher.exe\" or \"ffxivlauncher64.exe\"..."
     while [[ "$FFXIV_PID" == "" ]]; do
         sleep 1
-        FFXIV_PID="$(ps axo pid,cmd | grep -Pi 'ffxivlauncher(|64).exe' | grep -vi grep | sed -e 's/^[[:space:]]*//' | cut -d' ' -f1)"
+        FFXIV_PID="$(ps axo pid,cmd | grep -m 1 -Pi 'ffxivlauncher(|64).exe' | grep -vi grep | sed -e 's/^[[:space:]]*//' | cut -d' ' -f1)"
     done
 fi
 

--- a/setup-stage2.sh
+++ b/setup-stage2.sh
@@ -19,7 +19,7 @@ echo 'Sourcing the FFXIV environment'
 echo
 echo "Making sure wine isn't running anything"
 
-FFXIV_PID="$(ps axo pid,cmd | grep -Pi 'ffxivlauncher(|64).exe' | grep -vi grep | sed -e 's/^[[:space:]]*//' | cut -d' ' -f1)"
+FFXIV_PID="$(ps axo pid,cmd | grep -m1 -Pi 'ffxivlauncher(|64).exe' | grep -vi grep | sed -e 's/^[[:space:]]*//' | cut -d' ' -f1)"
 
 if [[ "$FFXIV_PID" != "" ]]; then
     warn "FFXIV launcher detected as running, forceably closing it"


### PR DESCRIPTION
on my machine, i launched the launcher via lutris, so there were multiple entries. the script breaks if there is are two results, so i constrained it to just the first (greo -m 1)

in the case of normal operation, noone should be able to tell the difference
in case of two ps entries, either should be fine

ideally there would be a dialogue to select from multiple results, but it is probably an edgecase anyway :)