### PR TITLE
Fix arch.sh variable escaping.

### DIFF
--- a/dependency-resolvers/arch.sh
+++ b/dependency-resolvers/arch.sh
@@ -76,7 +76,7 @@ RESOLVE_DEPS() {
     for DEP in "${MISSING_HARD_MISC[@]}"; do
         ARCH_MISC
     done
-    MISSING_UNIQUE=($(echo "${MISSING_UNIQUE[@]} | tr ' ' '\n' | sort -u | tr '\n' ' '"))
+    MISSING_UNIQUE=($(echo "${MISSING_UNIQUE[@]}" | tr ' ' '\n' | sort -u | tr '\n' ' '))
     echo
     warn "Installing the following dependencies:"
     echo 


### PR DESCRIPTION
I was trying to install this today and didn't have patchelf installed. when trying to install, it would error here after treating the entire sorting line as part of the variable containing the packages to install and breaking.