### PR TITLE
Fix a variety of setup bugs

### DIFF
--- a/dependency-resolvers/arch.sh
+++ b/dependency-resolvers/arch.sh
@@ -31,7 +31,6 @@ ARCH_MISC() {
             echo "You must reboot after applying these settings."
             exit 1
             ;;
-        *)
         "wine_deps")
             echo "Please refer to the lutris documentation here:"
             echo "https://github.com/lutris/docs/blob/master/WineDependencies.md"

--- a/setup-stage1.sh
+++ b/setup-stage1.sh
@@ -133,7 +133,7 @@ printf -v FFXIV_ENVIRON_FINAL '%s\nexport XIVLAUNCHER_PATH=%q' "$FFXIV_ENVIRON_F
 MANAGED_WINE=$(grep 'WineStartupType' $HOME/.xlcore/launcher.ini | sed 's/WineStartupType=\(.*\)/\1/')
 if [[ $MANAGED_WINE == *"Managed"* ]]; then
     # Find the actual wine version name inside the XLCore directory.
-    XLCORE_WINE_VERSION=$(ls -1tr $HOME/.xlcore/compatibilitytool/beta | tail -n1)
+    XLCORE_WINE_VERSION=$(ls -1trd $HOME/.xlcore/compatibilitytool/beta | tail -n1)
     # This is hard-coded in XLCore, and is vanishingly unlikely to ever change.
     PROTON_PATH="$HOME/.xlcore/compatibilitytool/beta/$XLCORE_WINE_VERSION/bin/wine"
 else

--- a/setup-stage1.sh
+++ b/setup-stage1.sh
@@ -5,7 +5,6 @@
 . helpers/funcs.sh
 . helpers/ensure-aur-xlcore.sh
 
-. config/xlcore.sh
 # Determine where the user wants to install the tools
 . config/ffxiv-tools-location.sh
 

--- a/setup-stage1.sh
+++ b/setup-stage1.sh
@@ -161,6 +161,7 @@ echo "FFXIV Game Location: $FFXIV_PATH"
 echo "wine Executable Location: $PROTON_PATH"
 echo "wine Distribution Path: $PROTON_DIST_PATH"
 echo "Wine Prefix: $WINEPREFIX"
+echo "Wine version: $XLCORE_WINE_VERSION"
 echo "XIVLauncher Windows Path: $XIVLAUNCHER_PATH"
 echo
 

--- a/setup-stage1.sh
+++ b/setup-stage1.sh
@@ -133,7 +133,7 @@ printf -v FFXIV_ENVIRON_FINAL '%s\nexport XIVLAUNCHER_PATH=%q' "$FFXIV_ENVIRON_F
 MANAGED_WINE=$(grep 'WineStartupType' $HOME/.xlcore/launcher.ini | sed 's/WineStartupType=\(.*\)/\1/')
 if [[ $MANAGED_WINE == *"Managed"* ]]; then
     # Find the actual wine version name inside the XLCore directory.
-    XLCORE_WINE_VERSION=$(ls -1trd $HOME/.xlcore/compatibilitytool/beta | tail -n1)
+    XLCORE_WINE_VERSION=$(basename "$(ls -1trd $HOME/.xlcore/compatibilitytool/beta/*/)" | tail -n1)
     # This is hard-coded in XLCore, and is vanishingly unlikely to ever change.
     PROTON_PATH="$HOME/.xlcore/compatibilitytool/beta/$XLCORE_WINE_VERSION/bin/wine"
 else

--- a/setup-stage2.sh
+++ b/setup-stage2.sh
@@ -35,7 +35,7 @@ echo "Making sure that Wine isn't running anything..."
 # runner (the FFXIV container's) to itself terminate all running programs?
 
 while true; do
-    GET_NEWEST_PID "WINE_EXE_PID" '[A-Z]:\\.*\.exe$'; PID_SUCCESS=$?
+    GET_NEWEST_PID "WINE_EXE_PID" '[A-Z]:\\.*\.exe'; PID_SUCCESS=$?
     [[ "$PID_SUCCESS" -ne 0 ]] && break
     warn "Detected Wine process ($WINE_EXE_PID). Forcing it to exit..."
     kill -9 "$WINE_EXE_PID"

--- a/setup-stage2.sh
+++ b/setup-stage2.sh
@@ -51,7 +51,6 @@ warn 'Note that the next step is destructive, meaning that if something goes wro
 echo 'Please make backups of both!'
 echo "Wine prefix: $WINEPREFIX"
 echo "wine distribution: $PROTON_DIST_PATH"
-echo "Wine version: $XLCORE_WINE_VERSION"
 
 PROMPT_BACKUP
 

--- a/setup-stage2.sh
+++ b/setup-stage2.sh
@@ -3,7 +3,6 @@
 . helpers/error.sh
 . helpers/prompt.sh
 . helpers/funcs.sh
-. config/xlcore.sh
 
 # Determine where the user wants to install the tools
 . config/ffxiv-tools-location.sh


### PR DESCRIPTION
- dependency-resolvers/arch.sh had a syntax error, making scripts unusable on arch
- config/xlcore.sh no longer exists so it should no longer be referenced.
- backups got picked up as a valid wine distribution
- FFXIV would sometimes not get killed by the script, regex was made more lenient