### PR TITLE
Fix syntax error in dependency-resolvers/arch.sh

### DIFF
--- a/dependency-resolvers/arch.sh
+++ b/dependency-resolvers/arch.sh
@@ -31,7 +31,6 @@ ARCH_MISC() {
             echo "You must reboot after applying these settings."
             exit 1
             ;;
-        *)
         "wine_deps")
             echo "Please refer to the lutris documentation here:"
             echo "https://github.com/lutris/docs/blob/master/WineDependencies.md"


### PR DESCRIPTION
Fixes a minor syntax error. I think  a line snuck in somehow.