### PR TITLE
Switch from which to command -v

### DIFF
--- a/helpers/deps.sh
+++ b/helpers/deps.sh
@@ -22,7 +22,7 @@ CHECK_DEP_64() {
 
 CHECK_TOOL() {
     DEP="$1"
-    CHECK="$(which "$DEP" 2>/dev/null)"
+    CHECK="$(command -v "$DEP" 2>/dev/null)"
     if [[ "$CHECK" == "" ]]; then
         return 1;
     else

--- a/setup-stage2.sh
+++ b/setup-stage2.sh
@@ -93,16 +93,16 @@ wine64 wineboot -s &>/dev/null
 
 echo 'Checking to see if wine binaries need their capabilities set'
 
-if [[ "$(getcap "$(which wine)")" == "" ]]; then
+if [[ "$(getcap "$(command -v wine)")" == "" ]]; then
     warn 'Setting network capture capabilities for ACT on your wine executables'
     warn 'This process must be run as root, so you will be prompted for your password'
     warn 'The commands to be run are as follows:'
     echo
-    warn 'sudo setcap cap_net_raw,cap_net_admin,cap_sys_ptrace=eip "$(which wine)"'
-    warn 'sudo setcap cap_net_raw,cap_net_admin,cap_sys_ptrace=eip "$(which wine64)"'
-    warn 'sudo setcap cap_net_raw,cap_net_admin,cap_sys_ptrace=eip "$(which wineserver)"'
+    warn 'sudo setcap cap_net_raw,cap_net_admin,cap_sys_ptrace=eip "$(command -v wine)"'
+    warn 'sudo setcap cap_net_raw,cap_net_admin,cap_sys_ptrace=eip "$(command -v wine64)"'
+    warn 'sudo setcap cap_net_raw,cap_net_admin,cap_sys_ptrace=eip "$(command -v wineserver)"'
     PROMPT_CONTINUE
-    sudo setcap cap_net_raw,cap_net_admin,cap_sys_ptrace=eip "$(which wine)"
-    sudo setcap cap_net_raw,cap_net_admin,cap_sys_ptrace=eip "$(which wine64)"
-    sudo setcap cap_net_raw,cap_net_admin,cap_sys_ptrace=eip "$(which wineserver)"
+    sudo setcap cap_net_raw,cap_net_admin,cap_sys_ptrace=eip "$(command -v wine)"
+    sudo setcap cap_net_raw,cap_net_admin,cap_sys_ptrace=eip "$(command -v wine64)"
+    sudo setcap cap_net_raw,cap_net_admin,cap_sys_ptrace=eip "$(command -v wineserver)"
 fi

--- a/setup-vpn-openvpn.sh
+++ b/setup-vpn-openvpn.sh
@@ -89,7 +89,7 @@ TARGET_USER="$USER"
 FFXIV_VPN_NAMESPACE="ffxiv"
 FFXIV_VPN_SUBNET="$IP_SUBNET"
 TARGET_INTERFACE="${NETWORK_INTERFACES[NETWORK_INTERFACES_ANSWER]}"
-OPENVPN="\$(which openvpn)"
+OPENVPN="\$(command -v openvpn)"
 
 EOF
 )
@@ -200,7 +200,7 @@ EOF
 SCRIPT_RUN_ACT=$(cat << EOF
 $SCRIPT_RUN_COMMON_PRE
 
-RUN_COMMAND "\$(which bash)" "$HOME/$FFXIV_TOOLS_LOCATION/ffxiv-run-act.sh"
+RUN_COMMAND "\$(command -v bash)" "$HOME/$FFXIV_TOOLS_LOCATION/ffxiv-run-act.sh"
 
 $SCRIPT_RUN_COMMON_POST
 EOF
@@ -209,7 +209,7 @@ EOF
 SCRIPT_RUN_GAME=$(cat << EOF
 $SCRIPT_RUN_COMMON_PRE
 
-RUN_COMMAND "\$(which bash)" "$HOME/$FFXIV_TOOLS_LOCATION/ffxiv-run-game.sh"
+RUN_COMMAND "\$(command -v bash)" "$HOME/$FFXIV_TOOLS_LOCATION/ffxiv-run-game.sh"
 
 $SCRIPT_RUN_COMMON_POST
 EOF
@@ -218,7 +218,7 @@ EOF
 SCRIPT_RUN_BOTH=$(cat << EOF
 $SCRIPT_RUN_COMMON_PRE
 
-RUN_COMMAND "\$(which bash)" "$HOME/$FFXIV_TOOLS_LOCATION/ffxiv-run-both.sh"
+RUN_COMMAND "\$(command -v bash)" "$HOME/$FFXIV_TOOLS_LOCATION/ffxiv-run-both.sh"
 
 $SCRIPT_RUN_COMMON_POST
 EOF

--- a/setup-vpn-other.sh
+++ b/setup-vpn-other.sh
@@ -158,7 +158,7 @@ EOF
 SCRIPT_RUN_ACT=$(cat << EOF
 $SCRIPT_RUN_COMMON_PRE
 
-RUN_COMMAND "\$(which bash)" "$HOME/$FFXIV_TOOLS_LOCATION/ffxiv-run-act.sh"
+RUN_COMMAND "\$(command -v bash)" "$HOME/$FFXIV_TOOLS_LOCATION/ffxiv-run-act.sh"
 
 $SCRIPT_RUN_COMMON_POST
 EOF
@@ -167,7 +167,7 @@ EOF
 SCRIPT_RUN_GAME=$(cat << EOF
 $SCRIPT_RUN_COMMON_PRE
 
-RUN_COMMAND "\$(which bash)" "$HOME/$FFXIV_TOOLS_LOCATION/ffxiv-run-game.sh"
+RUN_COMMAND "\$(command -v bash)" "$HOME/$FFXIV_TOOLS_LOCATION/ffxiv-run-game.sh"
 
 $SCRIPT_RUN_COMMON_POST
 EOF
@@ -176,7 +176,7 @@ EOF
 SCRIPT_RUN_BOTH=$(cat << EOF
 $SCRIPT_RUN_COMMON_PRE
 
-RUN_COMMAND "\$(which bash)" "$HOME/$FFXIV_TOOLS_LOCATION/ffxiv-run-both.sh"
+RUN_COMMAND "\$(command -v bash)" "$HOME/$FFXIV_TOOLS_LOCATION/ffxiv-run-both.sh"
 
 $SCRIPT_RUN_COMMON_POST
 EOF

--- a/setup-vpn.sh
+++ b/setup-vpn.sh
@@ -14,7 +14,7 @@ echo
 
 echo "Checking prerequisites..."
 
-HAS_OPENVPN="$(which openvpn 2> /dev/null)"
+HAS_OPENVPN="$(command -v openvpn 2> /dev/null)"
 
 if [[ "$HAS_OPENVPN" == "" ]]; then
     warn "You do not have the OpenVPN client installed."
@@ -50,7 +50,7 @@ else
 fi
 
 HAS_SYSTEMD=""
-HAS_SYSTEMCTL="$(which systemctl)"
+HAS_SYSTEMCTL="$(command -v systemctl)"
 
 echo
 echo


### PR DESCRIPTION
This changes all invocations of `which tool` to `command -v tool`. The reason for this is that `which` is, surprisingly, not specified by the [POSIX standards][1]. This wouldn't normally matter except, apparently, Arch doesn't install `which` by default. This leaves us with two options

* Add a `CHECK_TOOL` for the `which` command
* Switch to [`command -v`][2], which is the basically POSIX equivalent and supported by all shells

[1]: https://pubs.opengroup.org/onlinepubs/9699919799/
[2]: https://pubs.opengroup.org/onlinepubs/9699919799/utilities/command.html
