### PR TITLE
Use sudo for reading ffxiv pid environ

### DIFF
--- a/setup-stage1.sh
+++ b/setup-stage1.sh
@@ -118,7 +118,16 @@ declare -a FFXIV_ENVIRON_REQUIRED=(
 IFS=\| eval 'FFXIV_ENVIRON_REQ_RGX="^export (${FFXIV_ENVIRON_REQUIRED[*]})="'
 
 # Extract the currently running Lutris environment as properly quoted, newline-separated values.
-FFXIV_ENVIRON="$(cat /proc/$FFXIV_PID/environ | xargs -0 bash -c 'printf "export %q\n" "$@"' --)"
+get_ffxiv_pid_environ() {
+    if cat "/proc/$FFXIV_PID/environ" 2>/dev/null; then
+        return 0
+    fi
+    echo "Failed to cat /proc/$FFXIV_PID/environ. This can sometimes happen if your operating system only allows this action by root. We will try to rerun this command with sudo. You may be prompted for your password. The commands we will run with sudo are:" >&2
+    echo >&2
+    echo "  sudo cat /proc/$FFXIV_PID/environ" >&2
+    sudo cat /proc/$FFXIV_PID/environ
+}
+FFXIV_ENVIRON="$(get_ffxiv_pid_environ | xargs -0 bash -c 'printf "export %q\n" "$@"' --)"
 
 # Grab only the exact environment variables that we want.
 FFXIV_ENVIRON_FINAL="$(echo "$FFXIV_ENVIRON" | grep -P "$FFXIV_ENVIRON_REQ_RGX")"


### PR DESCRIPTION
For reasons I can't quite find on the internet, I was unable to read the environ file from processes created from xlcore (AUR), despite the file being owned by my user, having `0400` permissions.

The only thing I could find online was [a RedHat KB entry][1], which I can't read as I don't have a subscription. The fact that article exists makes me think that there's something in the kernel that prevents this, potentially related to cgroups, but I don't know enough about how xlcore/wine work to know if any of that could be related.

I can confirm that this seems specific to the FFXIV process as kicked off by xlcore from AUR on my machine -- I can enumerate environments of other processes just fine... So I'm really not sure what's going on

[1]: https://access.redhat.com/solutions/1446823
