### PR TITLE
Update xlcore wine binary path

### DIFF
--- a/setup-stage1.sh
+++ b/setup-stage1.sh
@@ -136,9 +136,16 @@ printf -v FFXIV_ENVIRON_FINAL '%s\nexport XIVLAUNCHER_PATH=%q' "$FFXIV_ENVIRON_F
 MANAGED_WINE=$(grep 'WineStartupType' $HOME/.xlcore/launcher.ini | sed 's/WineStartupType=\(.*\)/\1/')
 if [[ $MANAGED_WINE == *"Managed"* ]]; then
     # Find the actual wine version name inside the XLCore directory.
-    XLCORE_WINE_VERSION=$(ls -1tr $HOME/.xlcore/compatibilitytool/beta | tail -n1)
-    # This is hard-coded in XLCore, and is vanishingly unlikely to ever change.
-    PROTON_PATH="$HOME/.xlcore/compatibilitytool/beta/$XLCORE_WINE_VERSION/bin/wine"
+    # The base path is hard-coded in XLCore but may be different depending on version.
+    if [[ -d "$HOME/.xlcore/compatibilitytool/wine" ]]; then
+        # For versions of XLCore since https://github.com/goatcorp/XIVLauncher.Core/commit/877cfd14dd686dacc65aafd01ad38c5de4337ab6
+        XLCORE_WINE_BASE_DIR="$HOME/.xlcore/compatibilitytool/wine"
+    else
+        # For older XLCore versions
+        XLCORE_WINE_BASE_DIR="$HOME/.xlcore/compatibilitytool/beta"
+    fi
+    XLCORE_WINE_VERSION=$(ls -1tr $XLCORE_WINE_BASE_DIR | tail -n1)
+    PROTON_PATH="$XLCORE_WINE_BASE_DIR/$XLCORE_WINE_VERSION/bin/wine"
 else
     # Customized wine doesn't actually require us to find the version, since the full path is stored in the ini file.
     XLCORE_WINE_VERSION="Customized"


### PR DESCRIPTION
# Changes

XLCore updated the wine binary path recently in this commit: https://github.com/goatcorp/XIVLauncher.Core/commit/877cfd14dd686dacc65aafd01ad38c5de4337ab6

Updating the setup script to check for the new path. If new path exists, will use it, otherwise will fall back to old path for backwards compatibility.

# Testing

Confirmed running `./setup.sh` finds the correct wine paths with new XLCore version:

```
Detected the following information about your setup. If any of this looks incorrect, please abort and report a bug to the Github repo...
Runtime Environment: AUR XIVLauncher.Core
FFXIV Game Location: /home/travis/.xlcore/ffxiv
wine Executable Location: /home/travis/.xlcore/compatibilitytool/wine/wine-xiv-staging-fsync-git-10.8.r0.g47f77594-nolsc/bin/wine
wine Distribution Path: /home/travis/.xlcore/compatibilitytool/wine/wine-xiv-staging-fsync-git-10.8.r0.g47f77594-nolsc
Wine Prefix: /home/travis/.xlcore/wineprefix
XIVLauncher Windows Path: /opt/XIVLauncher/XIVLauncher.Core
```