### PR TITLE
fix: only consider directories when detecting latest wine version

### DIFF
--- a/setup-stage1.sh
+++ b/setup-stage1.sh
@@ -144,7 +144,7 @@ if [[ $MANAGED_WINE == *"Managed"* ]]; then
         # For older XLCore versions
         XLCORE_WINE_BASE_DIR="$HOME/.xlcore/compatibilitytool/beta"
     fi
-    XLCORE_WINE_VERSION=$(ls -1tr $XLCORE_WINE_BASE_DIR | tail -n1)
+    XLCORE_WINE_VERSION=$(ls -1trd "$XLCORE_WINE_BASE_DIR"/*/ | awk -F/ '{print $(NF-1)}' | tail -n1)
     PROTON_PATH="$XLCORE_WINE_BASE_DIR/$XLCORE_WINE_VERSION/bin/wine"
 else
     # Customized wine doesn't actually require us to find the version, since the full path is stored in the ini file.


### PR DESCRIPTION
The current directory listing does not differentiate between files and folders, which can cause the script to mistakenly select a backup archive instead of the latest wine version directory.

Update the listing command to explicitly target only subdirectories. This ensures backup files are ignored. Correctly handles whitespace in directory names in case of an unusual .xlcore location.